### PR TITLE
feat: add sitemap.xml and robots.txt for SEO and AI crawler protectio…  #23

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,11 +6,6 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
-        userAgent: '*',
-        allow: '/',
-        disallow: ['/api/', '/dashboard/'],
-      },
-      {
         userAgent: 'GPTBot',
         disallow: '/',
       },
@@ -29,6 +24,11 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: 'Google-Extended',
         disallow: '/',
+      },
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/dashboard/'],
       },
     ],
     sitemap: `${BASE_URL}/sitemap.xml`,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -13,7 +13,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     {
       url: `${BASE_URL}/auctions`,
       lastModified: new Date(),
-      changeFrequency: 'hourly',
+      changeFrequency: 'daily',
       priority: 0.9,
     },
     {
@@ -21,12 +21,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/dashboard`,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.7,
     },
   ]
 }


### PR DESCRIPTION
Implemented sitemap.xml and robots.txt using Next.js App Router conventions to improve SEO and block AI crawlers from scraping site content.

Changes
Added app/sitemap.ts - Auto-generates sitemap with all public routes
Added app/robots.ts - Controls crawler access and blocks AI bots
Features
Sitemap (/sitemap.xml)
Includes home, auctions, create, and dashboard pages
Proper priority and change frequency settings
Auto-updates lastModified timestamp
Robots (/robots.txt)
Allows standard search engine crawlers
Blocks /api/ and /dashboard/ from indexing
Blocks AI crawlers:
GPTBot (OpenAI)
ChatGPT-User
CCBot (Common Crawl)
anthropic-ai
Google-Extended (Bard/Gemini training)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic site sitemap covering main pages (root, auctions, create).
  * Added robots configuration to control crawler access, explicitly blocking certain AI bots and restricting /api/ and /dashboard/ access.

* **Chores**
  * Removed the dashboard route from the public sitemap.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->