### PR TITLE
Use Promise.all(promises) in English-auction to fetch them in parallel

### DIFF
--- a/lib/services/english-auction-service.ts
+++ b/lib/services/english-auction-service.ts
@@ -26,12 +26,17 @@ export class EnglishAuctionService implements IAuctionService {
 
     if (client) {
       try {
-        auctionedTokenName = await getTokenName(client, auctionData[6]);
-        biddingTokenName = await getTokenName(client, auctionData[8]);
-      } catch (error) {
-        console.warn("Error fetching token names:", error);
-      }
-    }
+  
+        [auctionedTokenName, biddingTokenName] = await Promise.all([
+        getTokenName(client, auctionData[6]),
+        getTokenName(client, auctionData[8])
+        
+      ]);
+    } 
+    catch (error) {
+    console.warn("Error fetching token names:", error);
+  }
+}
 
     return {
       protocol: "English",


### PR DESCRIPTION
### Why this matters:

 **Even though getLastNAuctions runs in parallel, if each individual auction takes twice as long to resolve its token names (e.g., 200ms + 200ms vs 200ms total), the entire dashboard load time increases. Applying this fix to mapAuctionData in all service files (english, allpay, dutch, etc.) will ensure maximum performance.**


**Location**: `lib\services\english-auction-service.ts`

### Before:
```
if (client) {
  try {
    auctionedTokenName = await getTokenName(client, auctionData[6]); // Waits for network
    biddingTokenName = await getTokenName(client, auctionData[8]);   // Waits for network again
  } catch (error) {
    console.warn("Error fetching token names:", error);
  }
}

```
### After:

```
if (client) {
  try {
    // Fetch both token names simultaneously
    [auctionedTokenName, biddingTokenName] = await Promise.all([
      getTokenName(client, auctionData[6]),
      getTokenName(client, auctionData[8])
    ]);
  } catch (error) {
    console.warn("Error fetching token names:", error);
  }
}
```

@kaneki003  @DengreSarthak Please review , and can be merged, let me know if any issue/change I will fix that 

Closes #30 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized token lookup performance in auction operations by processing multiple token name requests concurrently, reducing overall load times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->