### PR TITLE
Fix Navbar Active Page Indicator Across All Pages

### DIFF
--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -36,26 +36,31 @@ export function Navbar() {
 					<span className="text-3xl font-bold text-primary">HAH!</span>
 					</Link>
 					<nav className="hidden md:flex items-center space-x-4">
-						{navItems.map((item) => (
-							<Link
-								key={item.path}
-								href={item.path}
-								className={cn(
-									"text-sm font-medium transition-colors hover:text-primary relative py-1.5",
-									pathname === item.path
-										? "text-foreground"
-										: "text-muted-foreground"
-								)}
-							>
-								{item.name}
-								{pathname === item.path && (
-									<motion.div
-										className="absolute -bottom-px left-0 h-[2px] w-full bg-primary"
-										layoutId="navbar-underline"
-									/>
-								)}
-							</Link>
-						))}
+						{navItems.map((item) => {
+							const isActive = item.path === "/" 
+								? pathname === "/" 
+								: pathname === item.path || pathname.startsWith(`${item.path}/`);
+							return (
+								<Link
+									key={item.path}
+									href={item.path}
+									className={cn(
+										"text-sm font-medium transition-colors hover:text-primary relative py-1.5",
+										isActive
+											? "text-foreground"
+											: "text-muted-foreground"
+									)}
+								>
+									{item.name}
+									{isActive && (
+										<motion.div
+											className="absolute -bottom-px left-0 h-[2px] w-full bg-primary"
+											layoutId="navbar-underline"
+										/>
+									)}
+								</Link>
+							);
+						})}
 					</nav>
 				</div>
 


### PR DESCRIPTION
Fixes #48 

Description
This PR resolves an issue where the navbar underline indicator only appeared on the homepage and did not work for other pages. The changes ensure that the active page is correctly highlighted in the navbar across all pages, including sub-pages.

Changes Made
- Updated the isActive logic in the Navbar component to handle trailing slashes and sub-page paths.
- Used [pathname === item.path || pathname.startsWith(](http://_vscodecontentref_/2)${item.path}/`)` to account for trailing slashes and sub-paths.
- Ensured the home page (/) still requires an exact match.
Verified compatibility with the trailingSlash: true configuration in next.config.ts.

Video

https://github.com/user-attachments/assets/b25c9e1c-4124-4b5f-8133-773c1b2cb2d3




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation bar active state now correctly reflects your current location, including parent items when browsing subpages and nested routes. This provides clearer visual feedback as you navigate throughout the application, going beyond simple exact path matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->